### PR TITLE
CR-47-FE | Refactor: Organiztion card with API data from DB

### DIFF
--- a/front-end/src/components/pages/cards/OrganizationCard.jsx
+++ b/front-end/src/components/pages/cards/OrganizationCard.jsx
@@ -1,61 +1,103 @@
-import logoExample from '../../assets/images_default/logo_example.png';
+import { useEffect, useState } from 'react';
 import { FaHeart, FaMapMarkerAlt, FaPhoneAlt, FaEnvelope, FaGlobe } from 'react-icons/fa';
+import { fetchOrganizations } from '../../../utils/apiReqests';
+import { formatServices, formatAddress } from '../../../utils/formatData';
+import logoExample from '../../assets/images_default/logo_example.png';
 
 function OrganizationCard() {
-  const organizationLogo = null;
+  const [organizations, setOrganizations] = useState([]);
+  const [isLoading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  const formData = {
-    logo: organizationLogo || logoExample,
-    name: 'Habitat for Humanity',
-    address: '123 Main St',
-    city: 'Springfield',
-    state: 'MA',
-    zipCode: '01103',
-    phone: '413-555-1234',
-    email: 'contact@habitat.org',
-    website: 'https://habitatforhumanity.org',
-  };
+  useEffect(() => {
+    fetchOrganizations()
+      .then((response) => {
+        setOrganizations(response.data);
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error('Error fetching organizations:', error);
+        setError(error);
+        setLoading(false);
+      });
+  }, []);
 
   return (
-    <div className="p-4">
-      <div className="flex flex-col bg-white border shadow-lg rounded-lg w-full p-4">
-        {/* First line */}
-        <div className="flex items-center justify-between lg:ml-10 mt-5">
-          <div className="lg:w-1/6 xs:w-1/3 md:w-1/4">
-            <img src={formData.logo} alt={`${formData.name} logo`} className="w-full h-full object-contain" />
-          </div>
-          <h1 className="font-bold text-lg flex-1 text-center">{formData.name}</h1>
-          <FaHeart className="text-2xl text-red-500 lg:mr-10" />
-        </div>
+    <div className="p-4 flex flex-col gap-4">
+      {/* Organization details */}
+      {isLoading ? (
+        <p className="text-center">Loading...</p>
+      ) : error ? (
+        <p>Error: {error}</p>
+      ) : (
+        organizations.map((org) => (
+          <div key={org.id} className="flex flex-col bg-white border shadow-lg rounded-lg w-full p-4">
+            {/* Organization Card Header */}
+            <div className="flex items-center justify-between lg:ml-10 mt-1 mb-8">
+              {/* Logo */}
+              {org.logo ? (
+                <div className="lg:w-1/6 xs:w-1/3 md:w-1/4">
+                  <img
+                    src={logoExample || org.logo}
+                    alt={`${org.name || 'Unknown Organization'} logo`}
+                    className="w-full h-full object-contain"
+                  />
+                </div>
+              ) : (
+                <div className="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center text-gray-500 self-center">
+                  LOGO
+                </div>
+              )}
+              <h1 className="font-bold text-lg flex-1 text-center self-center">{org.name}</h1>
+              {/* Heart Icon for Favorites - status to be implemented */}
+              <FaHeart className="text-2xl text-red-500 lg:mr-10 self-center" />
+            </div>
 
-        {/* Info about organization */}
-        <div className="text-left lg:ml-10 mt-8">
-          {/* Address */}
-          <div className="flex items-center mb-2">
-            <FaMapMarkerAlt className="mr-2" />
-            <p>
-              {formData.address}, {formData.city}, {formData.state} {formData.zipCode}
-            </p>
+            {/* Info about organization */}
+            <div className="text-left lg:ml-10">
+              {/* Address */}
+              <div className="flex items-top mb-2">
+                {org.addresses.length > 0 ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 md:gap-4">
+                    {org.addresses.map((address, index) => (
+                      <div key={index} className="flex items-start">
+                        <FaMapMarkerAlt className="mr-3" />
+                        <p>{formatAddress(address)}</p>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex items-center">
+                    <FaMapMarkerAlt className="mr-2" />
+                    <p className="text-gray-400">&nbsp;</p>
+                  </div>
+                )}
+              </div>
+              {/* Email */}
+              <div className="flex items-center mb-2">
+                <FaEnvelope className="mr-2" />
+                <a href={`mailto:${org.email}`}>{org.email}</a>
+              </div>
+              {/* Website */}
+              <div className="flex items-center mb-2">
+                <FaGlobe className="mr-2" />
+                <a href={org.website || '#'} target="_blank" rel="noopener noreferrer">
+                  {org.website || ''}
+                </a>
+              </div>
+              {/* Phone */}
+              <div className="flex items-center mb-2">
+                <FaPhoneAlt className="mr-2" />
+                <p>{org.phone || ''}</p>
+              </div>
+              <div className="mt-4">
+                <h2 className="font-bold text-lg">Services:</h2>
+                <p>{formatServices(org.org_services)}</p>
+              </div>
+            </div>
           </div>
-          {/* Email */}
-          <div className="flex items-center mb-2">
-            <FaEnvelope className="mr-2" />
-            <a href={`mailto:${formData.email}`}>{formData.email}</a>
-          </div>
-          {/* Website */}
-          <div className="flex items-center mb-2">
-            <FaGlobe className="mr-2" />
-            <a href={formData.website} target="_blank" rel="noopener noreferrer">
-              {formData.website}
-            </a>
-          </div>
-          {/* Phone */}
-          <div className="flex items-center mb-2">
-            <FaPhoneAlt className="mr-2" />
-            <p>{formData.phone}</p>
-          </div>
-        </div>
-      </div>
+        ))
+      )}
     </div>
   );
 }

--- a/front-end/src/components/pages/volunteer/Favorites.jsx
+++ b/front-end/src/components/pages/volunteer/Favorites.jsx
@@ -4,7 +4,7 @@ function Volunteering() {
   return (
     <div className="mt-20">
       <OrganizationCard />
-      <OrganizationCard />
+      {/*<OrganizationCard />*/}
     </div>
   );
 }

--- a/front-end/src/components/pages/volunteer/Volunteering.jsx
+++ b/front-end/src/components/pages/volunteer/Volunteering.jsx
@@ -4,7 +4,7 @@ function Volunteering() {
   return (
     <div className="mt-20">
       <OrganizationCard />
-      <OrganizationCard />
+      {/*<OrganizationCard />*/}
     </div>
   );
 }

--- a/front-end/src/data/services.js
+++ b/front-end/src/data/services.js
@@ -1,0 +1,12 @@
+export const services = [
+  { id: 1, name: 'Food service' },
+  { id: 2, name: 'Transportation' },
+  { id: 3, name: 'Education' },
+  { id: 4, name: 'Sports&Recreation' },
+  { id: 5, name: 'Attractions' },
+  { id: 6, name: 'Housing&Facilities' },
+  { id: 7, name: 'Legal&Advocacy' },
+  { id: 8, name: 'Hobbies&Crafts' },
+  { id: 9, name: 'Arts&Culture' },
+  { id: 10, name: 'Health&Medicine' },
+];

--- a/front-end/src/utils/apiReqests.js
+++ b/front-end/src/utils/apiReqests.js
@@ -53,3 +53,12 @@ export const logout = async () => {
     console.error('Logout error:', error);
   }
 };
+
+export const fetchOrganizations = async () => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}organizations`, {});
+    return response;
+  } catch (error) {
+    throw error.response.data;
+  }
+};

--- a/front-end/src/utils/formatData.js
+++ b/front-end/src/utils/formatData.js
@@ -1,0 +1,21 @@
+import { services } from '../data/services';
+
+export function formatServices(orgServices) {
+  if (!orgServices || orgServices.length === 0) {
+    return 'No services available.';
+  }
+
+  // Map service IDs to service names and join them with ';'
+  const serviceNames = orgServices.map((service) => {
+    const serviceName = services.find((s) => s.id === service.service_id)?.name || '';
+    return serviceName;
+  });
+
+  return serviceNames.join('; ');
+}
+
+export function formatAddress(address) {
+  const { address: street, city, state, zip_code } = address || {};
+
+  return [street || '', city || '', state || '', zip_code || ''].filter(Boolean).join(', ');
+}


### PR DESCRIPTION
This PR implements the organization card by fetching data from the back-end API.

### Changes:
- Added Get request to fetch /organizations
- Updated the organization card to retrieve data from the back-end API.
- Added utility functions for handling addresses and services.
- Integrated API responses for organization details, addresses, and services.

### Not Implemented:
- Organization cards are not filtered by volunteer request status and favorite status.
- All available organization cards are displayed on the Volunteering and Favorites dashboard for Volunteers.

![Screenshot 2024-12-12 09 55 45](https://github.com/user-attachments/assets/f175b345-c537-473d-b7e5-021502b39eb7)

![Screenshot 2024-12-12 09 56 26](https://github.com/user-attachments/assets/21a877d5-3d3d-4e9b-a083-b68cee549f6b)


